### PR TITLE
IR address (NEC protocol) + longer RX delay.

### DIFF
--- a/infrared_controller.c
+++ b/infrared_controller.c
@@ -132,7 +132,7 @@ void infrared_controller_send(InfraredController* controller) {
 
     InfraredMessage message = {
         .protocol = InfraredProtocolNEC,
-        .address = 0x00,
+        .address = 0x42,
         .command = (controller->team == TeamRed) ? IR_COMMAND_RED_TEAM : IR_COMMAND_BLUE_TEAM};
 
     FURI_LOG_I(
@@ -161,7 +161,7 @@ bool infrared_controller_receive(InfraredController* controller) {
 
     infrared_worker_rx_start(controller->worker);
 
-    furi_delay_ms(50);
+    furi_delay_ms(250);
 
     infrared_worker_rx_stop(controller->worker);
 

--- a/laser_tag_icons.c
+++ b/laser_tag_icons.c
@@ -3,6 +3,7 @@
 #include <gui/icon_i.h>
 
 const uint8_t laser_gun_icon_data[] = {
+    0,
     0b00000000,
     0b00000000,
     0b00000001,
@@ -22,6 +23,7 @@ const uint8_t laser_gun_icon_data[] = {
 };
 
 const uint8_t health_icon_data[] = {
+    0,
     0b00001100,
     0b00110000,
     0b00011110,
@@ -41,6 +43,7 @@ const uint8_t health_icon_data[] = {
 };
 
 const uint8_t ammo_icon_data[] = {
+    0,
     0b00011000,
     0b00011000,
     0b00111100,
@@ -60,6 +63,7 @@ const uint8_t ammo_icon_data[] = {
 };
 
 const uint8_t team_red_icon_data[] = {
+    0,
     0b00011000,
     0b00011000,
     0b00111100,
@@ -79,6 +83,7 @@ const uint8_t team_red_icon_data[] = {
 };
 
 const uint8_t team_blue_icon_data[] = {
+    0,
     0b11100111,
     0b11100111,
     0b11000011,
@@ -98,6 +103,7 @@ const uint8_t team_blue_icon_data[] = {
 };
 
 const uint8_t game_over_icon_data[] = {
+    0,
     0b11111111,
     0b11111111,
     0b10000000,


### PR DESCRIPTION
When the IR address is 0, a different protocol decoder is matching our signal, causing the command to be incorrect.  By setting the address to 0x42 (some random value that seems to work for both the red/blue messages) we are able to correctly decode the command.

The value of 50 wasn't long enough to receive the IR blast.  I increased it to 250, so I'm able to use one Flipper and receive on the other.  I'm not sure what the "correct" value should be here?