### PR TITLE
Up button scans EM4100 health tag.

### DIFF
--- a/infrared_controller.c
+++ b/infrared_controller.c
@@ -187,3 +187,19 @@ bool infrared_controller_receive(InfraredController* controller) {
 
     return hit;
 }
+
+void infrared_controller_pause(InfraredController* controller) {
+    if(controller->worker_rx_active) {
+        FURI_LOG_I(TAG, "Stopping RX worker");
+        infrared_worker_rx_stop(controller->worker);
+        controller->worker_rx_active = false;
+    }
+}
+
+void infrared_controller_resume(InfraredController* controller) {
+    if(!controller->worker_rx_active) {
+        FURI_LOG_I(TAG, "Starting RX worker");
+        infrared_worker_rx_start(controller->worker);
+        controller->worker_rx_active = true;
+    }
+}

--- a/infrared_controller.h
+++ b/infrared_controller.h
@@ -10,6 +10,8 @@ void infrared_controller_free(InfraredController* controller);
 void infrared_controller_set_team(InfraredController* controller, LaserTagTeam team);
 void infrared_controller_send(InfraredController* controller);
 bool infrared_controller_receive(InfraredController* controller);
+void infrared_controller_pause(InfraredController* controller);
+void infrared_controller_resume(InfraredController* controller);
 
 #define IR_COMMAND_RED_TEAM  0xA1
 #define IR_COMMAND_BLUE_TEAM 0xB2

--- a/lfrfid_reader.c
+++ b/lfrfid_reader.c
@@ -1,0 +1,117 @@
+#include "lfrfid_reader.h"
+#include <lfrfid/protocols/lfrfid_protocols.h>
+#include <toolbox/protocols/protocol_dict.h>
+#include <lib/lfrfid/lfrfid_worker.h>
+
+#define TAG "LfRfid_Reader"
+
+typedef enum {
+    LFRFIDReaderEventTagRead = (1 << 0),
+    LFRFIDReaderEventStopThread = (1 << 1),
+    LFRFIDReaderEventAll = (LFRFIDReaderEventTagRead | LFRFIDReaderEventStopThread),
+} LFRFIDReaderEventType;
+
+struct LFRFIDReader {
+    char* requested_protocol;
+    ProtocolId protocol;
+    ProtocolDict* dict;
+    LFRFIDWorker* worker;
+    FuriThread* thread;
+    LFRFIDReaderTagCallback callback;
+    void* callback_context;
+};
+
+static void lfrfid_cli_read_callback(LFRFIDWorkerReadResult result, ProtocolId proto, void* ctx) {
+    furi_assert(ctx);
+    LFRFIDReader* context = ctx;
+    if(result == LFRFIDWorkerReadDone) {
+        context->protocol = proto;
+        furi_thread_flags_set(furi_thread_get_id(context->thread), LFRFIDReaderEventTagRead);
+    }
+}
+
+LFRFIDReader* lfrfid_reader_alloc() {
+    LFRFIDReader* reader = malloc(sizeof(LFRFIDReader));
+    reader->protocol = PROTOCOL_NO;
+    reader->dict = protocol_dict_alloc(lfrfid_protocols, LFRFIDProtocolMax);
+    reader->worker = lfrfid_worker_alloc(reader->dict);
+
+    return reader;
+}
+
+void lfrfid_reader_set_tag_callback(
+    LFRFIDReader* reader,
+    char* requested_protocol,
+    LFRFIDReaderTagCallback callback,
+    void* context) {
+    furi_assert(reader);
+    furi_assert(requested_protocol);
+    reader->requested_protocol = requested_protocol;
+    reader->callback = callback;
+    reader->callback_context = context;
+}
+
+static int32_t lfrfid_reader_start_thread(void* ctx) {
+    LFRFIDReader* reader = (LFRFIDReader*)ctx;
+    furi_thread_flags_clear(LFRFIDReaderEventAll);
+    lfrfid_worker_start_thread(reader->worker);
+    lfrfid_worker_read_start(
+        reader->worker, LFRFIDWorkerReadTypeASKOnly, lfrfid_cli_read_callback, reader);
+    while(true) {
+        uint32_t flags = furi_thread_flags_wait(LFRFIDReaderEventAll, FuriFlagWaitAny, 100);
+
+        if(flags != (unsigned)FuriFlagErrorTimeout) {
+            if((flags & LFRFIDReaderEventTagRead) == LFRFIDReaderEventTagRead) {
+                furi_thread_flags_clear(LFRFIDReaderEventTagRead);
+                if(reader->protocol != PROTOCOL_NO) {
+                    const char* protocol_name =
+                        protocol_dict_get_name(reader->dict, reader->protocol);
+                    if(strcmp(protocol_name, reader->requested_protocol) == 0) {
+                        size_t size = protocol_dict_get_data_size(reader->dict, reader->protocol);
+                        uint8_t* data = malloc(size);
+                        protocol_dict_get_data(reader->dict, reader->protocol, data, size);
+                        if(reader->callback) {
+                            FURI_LOG_D(TAG, "Tag %s detected", protocol_name);
+                            reader->callback(data, size, reader->callback_context);
+                        } else {
+                            FURI_LOG_W(TAG, "No callback set for tag %s", protocol_name);
+                        }
+                        free(data);
+                    } else {
+                        FURI_LOG_W(TAG, "Unsupported tag %s, expected EM4100", protocol_name);
+                    }
+                }
+                reader->protocol = PROTOCOL_NO;
+                lfrfid_worker_read_start(
+                    reader->worker, LFRFIDWorkerReadTypeASKOnly, lfrfid_cli_read_callback, reader);
+            } else if((flags & LFRFIDReaderEventStopThread) == LFRFIDReaderEventStopThread) {
+                break;
+            }
+        }
+    }
+    lfrfid_worker_stop(reader->worker);
+    lfrfid_worker_stop_thread(reader->worker);
+    FURI_LOG_D(TAG, "LfRfidReader thread exiting");
+    return 0;
+}
+
+void lfrfid_reader_start(LFRFIDReader* reader) {
+    reader->thread =
+        furi_thread_alloc_ex("lfrfid_reader", 2048, lfrfid_reader_start_thread, reader);
+    furi_thread_start(reader->thread);
+}
+
+void lfrfid_reader_stop(LFRFIDReader* reader) {
+    if(reader->thread) {
+        furi_thread_flags_set(furi_thread_get_id(reader->thread), LFRFIDReaderEventStopThread);
+        furi_thread_join(reader->thread);
+        reader->thread = NULL;
+    }
+}
+
+void lfrfid_reader_free(LFRFIDReader* reader) {
+    lfrfid_reader_stop(reader);
+    protocol_dict_free(reader->dict);
+    lfrfid_worker_free(reader->worker);
+    free(reader);
+}

--- a/lfrfid_reader.h
+++ b/lfrfid_reader.h
@@ -1,0 +1,57 @@
+#pragma once
+
+/**
+* @file lfrfid_reader.h
+* @brief EM4100 tag reader, inspired by applications/main/lfrfid/lfrfid_cli.c
+* @details This file contains the declaration of the LFRFIDReader structure and its functions. You typically allocate a new LFRFIDReader, set the tag detection callback, start the reader. The tag detection callback is called each time a tag is detected. Once you are done, you stop the reader and free it.
+* @author CodeAllNight (MrDerekJamison)
+*/
+
+#include <furi.h>
+
+typedef struct LFRFIDReader LFRFIDReader;
+
+/**
+ * @brief Callback function for tag detection.
+ * @param data Tag data.
+ * @param length Tag data length.
+ * @param context Callback context.
+ */
+typedef void (*LFRFIDReaderTagCallback)(uint8_t* data, uint8_t length, void* context);
+
+/**
+ * @brief Allocates a new LFRFIDReader.
+ * @return LFRFIDReader* Pointer to the allocated LFRFIDReader.
+ */
+LFRFIDReader* lfrfid_reader_alloc();
+
+/**
+ * @brief Sets the tag detection callback.
+ * @param reader LFRFIDReader to set the callback for.
+ * @param requested_protocol Requested protocol, e.g. "EM4100".
+ * @param callback Callback function.
+ * @param context Callback context.
+ */
+void lfrfid_reader_set_tag_callback(
+    LFRFIDReader* reader,
+    char* requested_protocol,
+    LFRFIDReaderTagCallback callback,
+    void* context);
+
+/**
+ * @brief Starts the LFRFIDReader.
+ * @param reader LFRFIDReader to start.
+ */
+void lfrfid_reader_start(LFRFIDReader* reader);
+
+/**
+ * @brief Stops the LFRFIDReader.
+ * @param reader LFRFIDReader to stop.
+ */
+void lfrfid_reader_stop(LFRFIDReader* reader);
+
+/**
+ * @brief Frees the LFRFIDReader.
+ * @param reader LFRFIDReader to free.
+ */
+void lfrfid_reader_free(LFRFIDReader* reader);


### PR DESCRIPTION
Press "Up" during game play to scan a LF-RFID tag for 3 seconds.  It turns out that IR and RFID use same timers, so while scanning we have to stop the IR detection.  🥲  We should probably add some limits to only do a successful scan every N seconds.

EM4100 tag with "13 37 00 FD 0A" will increase ammo 0x0A for either player.
EM4100 tag with "13 37 A1 FD 0A" will increase ammo 0x0A for Red player.
EM4100 tag with "13 37 B2 FD 0A" will increase ammo 0x0A for Blue player.
You can change 0A for different ammo refill amounts.
