### PR TITLE
Fix thread leak

### DIFF
--- a/infrared_controller.c
+++ b/infrared_controller.c
@@ -59,14 +59,14 @@ void update_infrared_board_status(InfraredController* controller) {
     }
 }
 
-static int32_t infrared_reset(void* context) {
+static void infrared_reset(void* context, uint32_t arg) {
+    UNUSED(arg);
     InfraredController* controller = (InfraredController*)context;
     // furi_stream_buffer_reset(instance->stream) not exposed to the API.
     // infrared_worker_rx_stop calls it internally.
     infrared_worker_rx_stop(controller->worker);
     infrared_worker_rx_start(controller->worker);
     controller->processing_signal = false;
-    return 0;
 }
 
 static void infrared_rx_callback(void* context, InfraredWorkerSignal* received_signal) {
@@ -109,8 +109,7 @@ static void infrared_rx_callback(void* context, InfraredWorkerSignal* received_s
     }
 
     FURI_LOG_I(TAG, "RX callback completed");
-    FuriThread* thread = furi_thread_alloc_ex("InfraredReset", 512, infrared_reset, controller);
-    furi_thread_start(thread);
+    furi_timer_pending_callback(infrared_reset, controller, FuriWaitForever);
 }
 
 InfraredController* infrared_controller_alloc() {

--- a/infrared_controller.c
+++ b/infrared_controller.c
@@ -109,7 +109,7 @@ static void infrared_rx_callback(void* context, InfraredWorkerSignal* received_s
     }
 
     FURI_LOG_I(TAG, "RX callback completed");
-    furi_timer_pending_callback(infrared_reset, controller, FuriWaitForever);
+    furi_timer_pending_callback(infrared_reset, controller, 0);
 }
 
 InfraredController* infrared_controller_alloc() {


### PR DESCRIPTION
Willyjl pointed out that the previous version was creating a thread every time the OK button was pressed but never freeing the resources when the thread ended.  We now use furi_timer_pending_callback to invoke the infrared reset on the RTOS timer thread instead of creating a new thread when OK button is pressed.

If we wanted to do more work on the thread, we can look into using the following for thread cleanup...
https://github.com/Next-Flip/Momentum-Firmware/blob/dev/lib/toolbox/run_parallel.c